### PR TITLE
Use rubocop and stylelink only in [test, development]

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,9 +6,9 @@ require_relative 'config/application'
 Rails.application.load_tasks
 
 # Clearing here because I want them to run in this order, specifically.
-task(:default).clear
+task(:check).clear
 
-task :default do
+task :check do
   %i[rubocop stylelint spec spinach].each do |task|
     begin
       Rake::Task[task].invoke

--- a/Rakefile
+++ b/Rakefile
@@ -6,9 +6,9 @@ require_relative 'config/application'
 Rails.application.load_tasks
 
 # Clearing here because I want them to run in this order, specifically.
-task(:check).clear
+task(:default).clear
 
-task :check do
+task :default do
   %i[rubocop stylelint spec spinach].each do |task|
     begin
       Rake::Task[task].invoke

--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -1,3 +1,5 @@
-require 'rubocop/rake_task'
+if ENV['RAILS_ENV'] != 'production'
+  require 'rubocop/rake_task'
 
-RuboCop::RakeTask.new
+  RuboCop::RakeTask.new
+end

--- a/lib/tasks/stylelint.rake
+++ b/lib/tasks/stylelint.rake
@@ -1,4 +1,4 @@
 desc 'Run stylelint'
 task :stylelint do
-  sh 'stylelint app/assets/**/*.scss --scss syntax'
+  sh 'stylelint app/assets/**/*.scss --scss syntax' if ENV['RAILS_ENV'] != 'production'
 end


### PR DESCRIPTION
we were using rubocop and stylelint when we were trying to deploy the app.
rubocop and stylelint are for development,test environment. During the deploy
using the function `load_tasks` these were being loaded.